### PR TITLE
Safari SyntaxError correction

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict'
-const CustomScroll = require('./dist/reactCustomScroll')
+var CustomScroll = require('./dist/reactCustomScroll')
 
 module.exports = CustomScroll


### PR DESCRIPTION
Mobile Safari throws: SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.