### PR TITLE
Update references on re-render.

### DIFF
--- a/src/main/customScroll.js
+++ b/src/main/customScroll.js
@@ -52,7 +52,7 @@ class CustomScroll extends Component {
     }
 
     this.setRefElement = elmKey => element => {
-      if (element && !this[elmKey]) {
+      if (element) {
         this[elmKey] = element
       }
     }
@@ -351,7 +351,7 @@ class CustomScroll extends Component {
   }
 
   setCustomScrollbarRef = elm => {
-    if (elm && !this.customScrollbarRef) {
+    if (elm) {
       this.customScrollbarRef = elm
     }
   }


### PR DESCRIPTION
Fix #53. If a scroll bar was rendered and then removed, the next render wouldn't update the references. Then `getBoundingClientRect` gets called on the removed element, which caused `isMouseEventOnCustomScrollbar` to fail.

Could check equality instead, but I'm not sure if it's necessary.