### PR TITLE
update webpack so ssr imports do not break

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = [{
     path: path.join(__dirname, 'dist'),
     filename: 'reactCustomScroll.js',
     library: 'ReactCustomScroll',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   module: {
     rules: [


### PR DESCRIPTION
fixes #50 

* there is a [known issue with webpack in v4](https://github.com/webpack/webpack/issues/6784) that makes it so `umd` build targets use the `window` variable, even if there is no code that requires it. the fix is found (here)[https://github.com/webpack/webpack/issues/6784#issuecomment-375941431] and implemented in this pr